### PR TITLE
Add DockerProfilesSpawner.

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -19,7 +19,12 @@ of provided Spawner configurations, and generates an options form from that list
 Using this mechanism, the administrator can provide users with a pre-approved
 selection of Spawner configurations.
 """
+
 import os
+import docker
+import json
+import re
+import urllib.request
 
 from tornado import gen, concurrent
 
@@ -128,7 +133,7 @@ class ProfilesSpawner(WrapSpawner):
 
     profiles = List(
         trait = Tuple( Unicode(), Unicode(), Type(Spawner), Dict() ),
-        default_value = [ ( 'Local Notebook Server', 'local', LocalProcessSpawner, 
+        default_value = [ ( 'Local Notebook Server', 'local', LocalProcessSpawner,
                             {'start_timeout': 15, 'http_timeout': 10} ) ],
         minlen = 1,
         config = True,
@@ -209,6 +214,66 @@ class ProfilesSpawner(WrapSpawner):
     def clear_state(self):
         super().clear_state()
         self.child_profile = ''
+
+class DockerProfilesSpawner(ProfilesSpawner):
+    default_profiles = List(
+        trait = Tuple( Unicode(), Unicode(), Type(Spawner), Dict() ),
+        default_value = [],
+        config = True,
+        help = """List of profiles to offer in addition to docker images for selection. Signature is:
+            List(Tuple( Unicode, Unicode, Type(Spawner), Dict )) corresponding to
+            profile display name, unique key, Spawner class, dictionary of spawner config options.
+
+            The first three values will be exposed in the input_template as {display}, {key}, and {type}"""
+        )
+
+    docker_spawner_args = Dict(
+        default_value = {},
+        config = True,
+        help = "Args to pass to DockerSpawner."
+    )
+
+    jupyterhub_docker_tag_re = re.compile('^.*jupyterhub$')
+
+    def _nvidia_args(self):
+        try:
+            resp = urllib.request.urlopen('http://localhost:3476/v1.0/docker/cli/json')
+            body = resp.read().decode('utf-8')
+            args =  json.loads(body)
+            return dict(
+                read_only_volumes={vol.split(':')[0]: vol.split(':')[1] for vol in args['Volumes']},
+                extra_create_kwargs={"volume_driver": args['VolumeDriver']},
+                extra_host_config={"devices": args['Devices']},
+            )
+        except urllib.error.URLError:
+            return {}
+
+
+    def _docker_profile(self, nvidia_args, image):
+        spawner_args = dict(container_image=image, network_name=self.user.name)
+        spawner_args.update(self.docker_spawner_args)
+        spawner_args.update(nvidia_args)
+        nvidia_enabled = "w/GPU" if len(nvidia_args) > 0 else "no GPU"
+        return ("Docker: (%s): %s"%(nvidia_enabled, image), "docker-%s"%(image), "dockerspawner.SystemUserSpawner", spawner_args)
+
+    def _jupyterhub_docker_tags(self):
+        include_jh_tags = lambda tag: self.jupyterhub_docker_tag_re.match(tag)
+        return filter(include_jh_tags, [tag for image in docker.from_env().images.list() for tag in image.tags])
+
+    def _docker_profiles(self):
+        return [self._docker_profile(self._nvidia_args(), tag) for tag in self._jupyterhub_docker_tags()]
+
+    @property
+    def profiles(self):
+        return self.default_profiles + self._docker_profiles()
+
+    @property
+    def options_form(self):
+        temp_keys = [ dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles]
+        temp_keys[0]['first'] = self.first_template
+        text = ''.join([ self.input_template.format(**tk) for tk in temp_keys ])
+        return self.form_template.format(input_template=text)
+
 
 # vim: set ai expandtab softtabstop=4:
 


### PR DESCRIPTION
Why:

It makes it simpler to give options for which image to use.
We need nvidia support.
This change addresses the need by:

Create a DockerProfilesSpawner that uses the ProfilesSpawner.
Side effects:

GPU support requires nvidia-docker otherwise no GPUs will be linked.