### PR TITLE
Filtered WrapSpawner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ configuration of Spawner classes while permitting:
    * configuration of Spawner classes that don't natively implement `options_form`
    * administrator control of allowed configuration changes
    * runtime choice of which Spawner backend to launch
+   
+FilteredSpawner allows the definition of profiles that can be assigned only to authenticated users belonging to a specific set of groups.Based over the original ProfilesSpawner it exploits a specific additional configuration profile parameter to specify the set of allowed groups or a * wildcard for enabling that specific profile for all the users
+
 
 ### Example
 
@@ -70,6 +73,29 @@ running as a local process or one of two different Docker Images to run within `
           ('Docker Python 2/3', 'systemuser', 'dockerspawner.SystemUserSpawner', dict(container_image="jupyterhub/systemuser")),
           ('Docker Python 2/3,R,Julia', 'datasciencesystemuser', 'dockerspawner.SystemUserSpawner', dict(container_image="jupyterhub/datasciencesystemuser")),
     ]
+   ```
+
+<b>FilteredSpawner</b> example
+   ```python
+   c.JupyterHub.spawner_class = 'wrapspawner.FilteredSpawner'
+   c.Spawner.http_timeout = 120
+   #------------------------------------------------------------------------------
+   # ProfilesSpawner configuration
+   #------------------------------------------------------------------------------
+   # List of profiles to offer for selection. Signature is:
+   #   List(Tuple( Unicode, Unicode, Type(Spawner), Dict, Unicode ))
+   # corresponding to profile display name, unique key, Spawner class,
+   # dictionary of spawner config options, comma separated list of authorized groups..
+   # 
+   # The first three values will be exposed in the input_template as {display},
+   # {key}, and {type}
+   #
+    c.ProfilesSpawner.default_profiles = [
+       ( "Sudospawner group1", 'sudospawner', 'sudospawner.SudoSpawner', {'cmd':['sudospawner-singleuser'], 'notebook_dir':''}, 'group1' ),
+       ( "Sudospawner group2", 'sudospawner', 'sudospawner.SudoSpawner', {'cmd':['sudospawner-singleuser'], 'notebook_dir':''}, 'group2' ),
+       ( "Global spawner", 'sudospawner', 'sudospawner.SudoSpawner', {'cmd':['sudospawner-singleuser'], 'notebook_dir':''}, '*' )
+
+]
    ```
 
 ## History

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -135,18 +135,14 @@ class ProfilesSpawner(WrapSpawner):
         2) administrator control of allowed configuration changes
         3) runtime choice of which Spawner backend to launch
     """
-
-    profiles = List(
+    default_profiles = List(
         trait = Tuple( Unicode(), Unicode(), Type(Spawner), Dict() ),
-        default_value = [ ( 'Local Notebook Server', 'local', LocalProcessSpawner,
-                            {'start_timeout': 15, 'http_timeout': 10} ) ],
-        minlen = 1,
+        default_value = [],
         config = True,
-        help = """List of profiles to offer for selection. Signature is:
-            List(Tuple( Unicode, Unicode, Type(Spawner), Dict )) corresponding to
-            profile display name, unique key, Spawner class, dictionary of spawner config options.
-
-            The first three values will be exposed in the input_template as {display}, {key}, and {type}"""
+        help = """List of profiles to offer in addition to docker images for selection. Signature is:
+                List(Tuple( Unicode, Unicode, Type(Spawner), Dict )) corresponding to
+                profile display name, unique key, Spawner class, dictionary of spawner config options.
+                The first three values will be exposed in the input_template as {display}, {key}, and {type}"""
         )
 
     child_profile = Unicode()
@@ -193,6 +189,7 @@ class ProfilesSpawner(WrapSpawner):
 
     def select_profile(self, profile):
         # Select matching profile, or do nothing (leaving previous or default config in place)
+        print("Profiles type {}".format(type(self.profiles)))
         for p in self.profiles:
             if p[1] == profile:
                 self.child_class = p[2]
@@ -205,7 +202,7 @@ class ProfilesSpawner(WrapSpawner):
         super().construct_child()
 
     def load_child_class(self, state):
-        try:
+        try: 
             self.child_profile = state['profile']
         except KeyError:
             raise KeyError('jupyterhub database might be outdated, please reset it, in the default configuration, just delete jupyterhub.sqlite')
@@ -219,6 +216,17 @@ class ProfilesSpawner(WrapSpawner):
     def clear_state(self):
         super().clear_state()
         self.child_profile = ''
+    
+    def _user_profiles(self):
+        #Simple test list to validate mechanism
+        test_list = [(self.user.name, 'sudospawner', 'sudospawner.SudoSpawner', {'cmd':['sudospawner-singleuser'], 'notebook_dir':''})]
+        return test_list
+    
+    @property
+    def profiles(self):
+        #return self._user_profiles
+        #New profiles are default profiles in addition to user_based profiles
+        return self.default_profiles + self._user_profiles()
 
 class DockerProfilesSpawner(ProfilesSpawner):
 

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -242,8 +242,8 @@ class FilteredSpawner(ProfilesSpawner):
         user = self.user.name
         cmd_result = subprocess.Popen("groups "+user, shell=True, stdout=subprocess.PIPE).stdout.read()
         #Get system default encoding
-		sys_encoding = sys.getdefaultencoding()
-		groups_list = cmd_result.decode(sys_encoding).split(':')[1].replace('\n', '').strip().split(' ')
+        sys_encoding = sys.getdefaultencoding()
+        groups_list = cmd_result.decode(sys_encoding).split(':')[1].replace('\n', '').strip().split(' ')
         return groups_list
     
     def _user_profiles(self):

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -251,6 +251,10 @@ class FilteredSpawner(ProfilesSpawner):
         valid_profiles = []
         for p in self.default_profiles:
             #Parse authorized groups
+            #If authorized_groups contained the all wildcard, pass it without groups check
+            if p[4] == '*':
+                valid_profiles.append((p[0], p[1], p[2], p[3]))            
+            #Check if profile is enabled for the user 
             authorized_groups = p[4].split(',')
             user_groups = self.get_user_groups()
             #Interesection between groups


### PR DESCRIPTION
Hi everyone, 
for internal purposes we had the necessity to integrate ProfileSpawner with a filter in order to provide to each user only an allowed set of profiles based on his group. We developed this feature in the FilteredSpawner class based on ProfileSpawner.

Each spawning profile has an additional parameter that allows to define a comma-separated list of authorized user groups. If * is specified instead of the comma-separated list the profile is available for all the users. 

We found this integration quite useful, and we'd like to share it with the community.

Details in the README.md, let me know for any questions.

Thank you. 
L.