### PR TITLE
Proxy current_port to child spawner, needed by batchspawner #58

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -129,6 +129,17 @@ class WrapSpawner(Spawner):
         else:
             return _yield_val(1)
 
+    # current_port proxy: batchspawner, #58 - select singleuser server
+    # on remote host
+    @property
+    def current_port(self):
+        return self.child_spawner.current_port
+
+    @current_port.setter
+    def current_port(self, value):
+        self.child_spawner.current_port = value
+
+
 class ProfilesSpawner(WrapSpawner):
 
     """ProfilesSpawner - leverages the Spawner options form feature to allow user-driven


### PR DESCRIPTION
This is minimal fix for compatibility jupyterhub/batchspawner#58.  It would be better to do this in a more general fashion, but this is the fast fix and we can improve later.

Currently no tests here.