### PR TITLE
Clear child_config when stopping servers

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -113,6 +113,7 @@ class WrapSpawner(Spawner):
         if self.child_spawner:
             self.child_spawner.clear_state()
         self.child_state = {}
+        self.child_config = {}
         self.child_spawner = None
 
     # proxy functions for start/poll/stop


### PR DESCRIPTION
- I talked with @minrk about the problem with config being saved, and
  apparently the right answer is that wrapspawner was not clearing the
  state properly.
- `.clear_state()` is a hook that is called anytime a spawner is
  stopped.  This needs to clear everything - and it was missing
  child_conf.
- Closes: #31
- Thanks to @minrk