### PR TITLE
Fix common_traits calculation

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -85,9 +85,9 @@ class WrapSpawner(Spawner):
 
             # link traits common between self and child
             common_traits = (
-              set(self._trait_values.keys()) &
-              set(self.child_spawner._trait_values.keys()) -
-              set(self.child_config.keys())
+                set(self.trait_names()) &
+                set(self.child_spawner.trait_names()) -
+                set(self.child_config.keys())
             )
             for trait in common_traits:
                 directional_link((self, trait), (self.child_spawner, trait))


### PR DESCRIPTION
With traitlets 5, a `trait_values()` method was added to `HasTraits` that seems like a better fit here.  Indeed it seems to resolve problems like #41 and others.

Without this change, but with traitlets 5 installed, a number of traits in `self.child_spawner._trait_values.keys()` are omitted relative to with traitlets 4.  Switching this to `self.child_spawner.trait_values().keys()` returns more of these but other ones as well.  This may be the consequence of some kind of effective `**metadata` argument "applied" in traitlets 4, I haven't looked.

I've marked this WIP because while it appears to fix the reproducer in #41, there may be other consequences and I'd like to try it out on my dev deployment before asking for a merge.  I would also encourage others who have seen traitlets 5 break their JupyterHub+wrapspawner deployments to try this out and report back.