### PR TITLE
Trigger child spawner's server property getter to make it exist

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -91,6 +91,10 @@ class WrapSpawner(Spawner):
             )
             for trait in common_traits:
                 directional_link((self, trait), (self.child_spawner, trait))
+
+            # trigger getter for child server property, is there a better fix?
+            _ = self.child_spawner.server
+
         return self.child_spawner
 
     def load_child_class(self, state):


### PR DESCRIPTION
This addresses problems like #44 where the child_spawner.server attribute doesn't exist because it needs to be provoked into existing by hitting its getter. This part of the Spawner code shows how server comes into existence or not.

Per discussion at the HPC call Tuesday, we'll proceed by

- Update the PR to comment the rather odd-looking line added here (done)
- Add references to issues that are closed by merging this PR
- Open a new issue to track a better fix longer term upon closing this