### PR TITLE
Link server manually since it is not a traitlet

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -147,6 +147,21 @@ class WrapSpawner(Spawner):
             else:
                 raise RuntimeError("No child spawner yet exists - can not get progress yet")
 
+    # Manually link server attribute since it is not a traitlet
+
+    @property
+    def server(self):
+        if not self.child_spawner:
+            self.construct_child()
+        return self.child_spawner.server
+
+    @server.setter
+    def server(self, server):
+        if not self.child_spawner:
+            self.construct_child()
+        self.child_spawner.server = server
+
+
 class ProfilesSpawner(WrapSpawner):
 
     """ProfilesSpawner - leverages the Spawner options form feature to allow user-driven


### PR DESCRIPTION
Here's an alternative PR to #50 that more explicitly makes the connection with the child spawner, based on a suggestion from @minrk.  I found it necessary in local testing with the config from @manics to guard against `not self.child_spawner` in the getter because otherwise (I think) Min's suggested implementation just keeps making the `child_spawner` the wrong way repeatedly.  Technically speaking I think the guard in the setter may be superfluous, I am not 100% sure.

The main thing this has going for it that it is more explicit compared to #50.  @mbmilligan do you want to make the call on these 2 PR alternatives?