### PR TITLE
New Custom Spawner 

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -417,7 +417,10 @@ class GDITSpawner(WrapSpawner):
                 with open(file) as f:
                     lines = f.readlines()
                     f.seek(0)
-                    new_profiles.append(tuple((prefix + lines[1],
+                    option = prefix + lines[1]
+                    option = option.replace("\n", "")
+                    option = re.sub("#JUPYTER", "",option, re.IGNORECASE)
+                    new_profiles.append(tuple((option,
                                                prefix + str(count), 'batchspawner.SlurmSpawner',
                                                dict(req_nprocs='1', req_partition='compute', req_runtime='24:00:00'),
                                                f.read())))

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -39,29 +39,28 @@ try:
 except ImportError:
     pass
 
-
 # Utility to create dummy Futures to return values through yields
 def _yield_val(x=None):
     f = concurrent.Future()
     f.set_result(x)
     return f
 
-
 class WrapSpawner(Spawner):
+
     # Grab this from constructor args in case some Spawner ever wants it
     config = Any()
 
     child_class = Type(LocalProcessSpawner, Spawner,
-                       config=True,
-                       help="""The class to wrap for spawning single-user servers.
+        config=True,
+        help="""The class to wrap for spawning single-user servers.
                 Should be a subclass of Spawner.
                 """
-                       )
+        )
 
     child_config = Dict(default_value={},
-                        config=True,
-                        help="Dictionary of config values to apply to wrapped spawner class."
-                        )
+        config=True,
+        help="Dictionary of config values to apply to wrapped spawner class."
+        )
 
     child_state = Dict(default_value={})
 
@@ -70,15 +69,15 @@ class WrapSpawner(Spawner):
     def construct_child(self):
         if self.child_spawner is None:
             self.child_spawner = self.child_class(
-                user=self.user,
-                db=self.db,
-                hub=self.hub,
-                authenticator=self.authenticator,
-                oauth_client_id=self.oauth_client_id,
-                server=self._server,
-                config=self.config,
+                user = self.user,
+                db   = self.db,
+                hub  = self.hub,
+                authenticator = self.authenticator,
+                oauth_client_id = self.oauth_client_id,
+                server = self._server,
+                config = self.config,
                 **self.child_config
-            )
+                )
             # initial state will always be wrong since it will see *our* state
             self.child_spawner.clear_state()
             if self.child_state:
@@ -86,9 +85,9 @@ class WrapSpawner(Spawner):
 
             # link traits common between self and child
             common_traits = (
-                    set(self.trait_names()) &
-                    set(self.child_spawner.trait_names()) -
-                    set(self.child_config.keys())
+                set(self.trait_names()) &
+                set(self.child_spawner.trait_names()) -
+                set(self.child_config.keys())
             )
             for trait in common_traits:
                 directional_link((self, trait), (self.child_spawner, trait))
@@ -164,6 +163,7 @@ class WrapSpawner(Spawner):
 
 
 class ProfilesSpawner(WrapSpawner):
+
     """ProfilesSpawner - leverages the Spawner options form feature to allow user-driven
         configuration of Spawner classes while permitting:
         1) configuration of Spawner classes that don't natively implement options_form
@@ -172,17 +172,17 @@ class ProfilesSpawner(WrapSpawner):
     """
 
     profiles = List(
-        trait=Tuple(Unicode(), Unicode(), Type(Spawner), Dict()),
-        default_value=[('Local Notebook Server', 'local', LocalProcessSpawner,
-                        {'start_timeout': 15, 'http_timeout': 10})],
-        minlen=1,
-        config=True,
-        help="""List of profiles to offer for selection. Signature is:
+        trait = Tuple( Unicode(), Unicode(), Type(Spawner), Dict() ),
+        default_value = [ ( 'Local Notebook Server', 'local', LocalProcessSpawner,
+                            {'start_timeout': 15, 'http_timeout': 10} ) ],
+        minlen = 1,
+        config = True,
+        help = """List of profiles to offer for selection. Signature is:
             List(Tuple( Unicode, Unicode, Type(Spawner), Dict )) corresponding to
             profile display name, unique key, Spawner class, dictionary of spawner config options.
 
             The first three values will be exposed in the input_template as {display}, {key}, and {type}"""
-    )
+        )
 
     child_profile = Unicode()
 
@@ -191,34 +191,33 @@ class ProfilesSpawner(WrapSpawner):
         <select class="form-control" name="profile" required autofocus>
         {input_template}
         </select>
-        <textfield></textfield>
         """,
-        config=True,
-        help="""Template to use to construct options_form text. {input_template} is replaced with
+        config = True,
+        help = """Template to use to construct options_form text. {input_template} is replaced with
             the result of formatting input_template against each item in the profiles list."""
-    )
+        )
 
     first_template = Unicode('selected',
-                             config=True,
-                             help="Text to substitute as {first} in input_template"
-                             )
+        config=True,
+        help="Text to substitute as {first} in input_template"
+        )
 
     input_template = Unicode("""
         <option value="{key}" {first}>{display}</option>""",
-                             config=True,
-                             help="""Template to construct {input_template} in form_template. This text will be formatted
+        config = True,
+        help = """Template to construct {input_template} in form_template. This text will be formatted
             against each item in the profiles list, in order, using the following key names:
             ( display, key, type ) for the first three items in the tuple, and additionally
             first = "checked" (taken from first_template) for the first item in the list, so that
             the first item starts selected."""
-                             )
+        )
 
     options_form = Unicode()
 
     def _options_form_default(self):
-        temp_keys = [dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles]
+        temp_keys = [ dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles ]
         temp_keys[0]['first'] = self.first_template
-        text = ''.join([self.input_template.format(**tk) for tk in temp_keys])
+        text = ''.join([ self.input_template.format(**tk) for tk in temp_keys ])
         return self.form_template.format(input_template=text)
 
     def options_from_form(self, formdata):
@@ -256,8 +255,8 @@ class ProfilesSpawner(WrapSpawner):
         super().clear_state()
         self.child_profile = ''
 
-
 class DockerProfilesSpawner(ProfilesSpawner):
+
     """DockerProfilesSpawner - leverages ProfilesSpawner to dynamically create DockerSpawner
         profiles dynamically by looking for docker images that end with "jupyterhub". Due to the
         profiles being dynamic the "profiles" config item from the ProfilesSpawner is renamed as
@@ -266,20 +265,20 @@ class DockerProfilesSpawner(ProfilesSpawner):
     """
 
     default_profiles = List(
-        trait=Tuple(Unicode(), Unicode(), Type(Spawner), Dict()),
-        default_value=[],
-        config=True,
-        help="""List of profiles to offer in addition to docker images for selection. Signature is:
+        trait = Tuple( Unicode(), Unicode(), Type(Spawner), Dict() ),
+        default_value = [],
+        config = True,
+        help = """List of profiles to offer in addition to docker images for selection. Signature is:
             List(Tuple( Unicode, Unicode, Type(Spawner), Dict )) corresponding to
             profile display name, unique key, Spawner class, dictionary of spawner config options.
 
             The first three values will be exposed in the input_template as {display}, {key}, and {type}"""
-    )
+        )
 
     docker_spawner_args = Dict(
-        default_value={},
-        config=True,
-        help="Args to pass to DockerSpawner."
+        default_value = {},
+        config = True,
+        help = "Args to pass to DockerSpawner."
     )
 
     jupyterhub_docker_tag_re = re.compile('^.*jupyterhub$')
@@ -288,7 +287,7 @@ class DockerProfilesSpawner(ProfilesSpawner):
         try:
             resp = urllib.request.urlopen('http://localhost:3476/v1.0/docker/cli/json')
             body = resp.read().decode('utf-8')
-            args = json.loads(body)
+            args =  json.loads(body)
             return dict(
                 read_only_volumes={vol.split(':')[0]: vol.split(':')[1] for vol in args['Volumes']},
                 extra_create_kwargs={"volume_driver": args['VolumeDriver']},
@@ -297,13 +296,13 @@ class DockerProfilesSpawner(ProfilesSpawner):
         except urllib.error.URLError:
             return {}
 
+
     def _docker_profile(self, nvidia_args, image):
         spawner_args = dict(container_image=image, network_name=self.user.name)
         spawner_args.update(self.docker_spawner_args)
         spawner_args.update(nvidia_args)
         nvidia_enabled = "w/GPU" if len(nvidia_args) > 0 else "no GPU"
-        return ("Docker: (%s): %s" % (nvidia_enabled, image), "docker-%s" % (image), "dockerspawner.SystemUserSpawner",
-                spawner_args)
+        return ("Docker: (%s): %s"%(nvidia_enabled, image), "docker-%s"%(image), "dockerspawner.SystemUserSpawner", spawner_args)
 
     def _jupyterhub_docker_tags(self):
         try:
@@ -321,9 +320,9 @@ class DockerProfilesSpawner(ProfilesSpawner):
 
     @property
     def options_form(self):
-        temp_keys = [dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles]
+        temp_keys = [ dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles]
         temp_keys[0]['first'] = self.first_template
-        text = ''.join([self.input_template.format(**tk) for tk in temp_keys])
+        text = ''.join([ self.input_template.format(**tk) for tk in temp_keys ])
         return self.form_template.format(input_template=text)
 
 
@@ -514,4 +513,6 @@ class CustomSpawner(WrapSpawner):
     def clear_state(self):
         super().clear_state()
         self.child_profile = ''
+
 # vim: set ai expandtab softtabstop=4:
+

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -373,8 +373,11 @@ class GDITSpawner(WrapSpawner):
             pass
         else:
             self.spawner_class = 'SlurmSpawner'
-        
-        pass
+
+        if 'system_profile_path' in kwargs['config']['GDITSpawner']:
+            self.system_profile_path = kwargs['config']['GDITSpawner']['system_profile_path']
+        else:
+            self.system_profile_path = os.path.dirname(self.config.JupyterHub.config_file) + "/jupyterhub/profiles"
 
     def _options_form_default(self):
         self._load_profiles_from_fs()
@@ -405,7 +408,7 @@ class GDITSpawner(WrapSpawner):
 
     def _load_profiles_from_fs(self):
         path = os.path.dirname(self.config.JupyterHub.config_file) + "/jupyterhub/profiles"
-        new_profiles = self._load_profiles(path, "System:")
+        new_profiles = self._load_profiles(self.system_profile_path, "System:")
         self.profiles = new_profiles
         path = os.path.expanduser('~') + "/../" + self.user.escaped_name + "/.jupyter/hub/profiles"
         new_profiles = self._load_profiles(path, "User:")

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -431,7 +431,7 @@ class CustomSpawner(WrapSpawner):
     def options_from_form(self, formdata):
         # Default to first profile if somehow none is provided
         self._load_profiles_from_fs()
-        self.config[self.spawner_class]['batch_script'] = str(formdata['batch_command'])
+        self.config[self.spawner_class]['batch_script'] = str(formdata['batch_command'][0])
         return dict(profile=formdata.get('profile', [self.profiles[0][1]])[0])
 
     def _load_profiles_from_fs(self):

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -366,6 +366,16 @@ class GDITSpawner(WrapSpawner):
 
     options_form = Unicode()
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if 'spawner_class' in kwargs['config']['GDITSpawner']:
+            self.spawner_class = kwargs['config']['GDITSpawner']['spawner_class']
+            pass
+        else:
+            self.spawner_class = 'SlurmSpawner'
+        
+        pass
+
     def _options_form_default(self):
         self._load_profiles_from_fs()
         temp_keys = [dict(display=p[0], key=p[1], type=p[2], id=p[1], first='') for p in self.profiles]
@@ -390,7 +400,7 @@ class GDITSpawner(WrapSpawner):
     def options_from_form(self, formdata):
         # Default to first profile if somehow none is provided
         self._load_profiles_from_fs()
-        self.config['SlurmSpawner']['batch_script'] = str(formdata['batch_command'])
+        self.config[self.spawner_class]['batch_script'] = str(formdata['batch_command'])
         return dict(profile=formdata.get('profile', [self.profiles[0][1]])[0])
 
     def _load_profiles_from_fs(self):
@@ -421,7 +431,7 @@ class GDITSpawner(WrapSpawner):
                     option = option.replace("\n", "")
                     option = re.sub("#JUPYTER", "",option, re.IGNORECASE)
                     new_profiles.append(tuple((option,
-                                               prefix + str(count), 'batchspawner.SlurmSpawner',
+                                               prefix + str(count), 'batchspawner.' + self.spawner_class,
                                                dict(req_nprocs='1', req_partition='compute', req_runtime='24:00:00'),
                                                f.read())))
         except Exception as e:

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -379,6 +379,11 @@ class GDITSpawner(WrapSpawner):
         else:
             self.system_profile_path = os.path.dirname(self.config.JupyterHub.config_file) + "/jupyterhub/profiles"
 
+        if 'user_profile_path' in kwargs['config']['GDITSpawner']:
+            self.user_profile_path = kwargs['config']['GDITSpawner']['user_profile_path']
+        else:
+            self.user_profile_path = os.path.expanduser('~') + "/../"
+
     def _options_form_default(self):
         self._load_profiles_from_fs()
         temp_keys = [dict(display=p[0], key=p[1], type=p[2], id=p[1], first='') for p in self.profiles]
@@ -407,10 +412,9 @@ class GDITSpawner(WrapSpawner):
         return dict(profile=formdata.get('profile', [self.profiles[0][1]])[0])
 
     def _load_profiles_from_fs(self):
-        path = os.path.dirname(self.config.JupyterHub.config_file) + "/jupyterhub/profiles"
         new_profiles = self._load_profiles(self.system_profile_path, "System:")
         self.profiles = new_profiles
-        path = os.path.expanduser('~') + "/../" + self.user.escaped_name + "/.jupyter/hub/profiles"
+        path = self.user_profile_path + self.user.escaped_name + "/.jupyter/hub/profiles"
         new_profiles = self._load_profiles(path, "User:")
         for profile in new_profiles:
             self.profiles.append(profile)

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -326,15 +326,15 @@ class DockerProfilesSpawner(ProfilesSpawner):
         return self.form_template.format(input_template=text)
 
 
-class CustomSpawner(WrapSpawner):
-    """CustomSpawner allows batch commands to be displayed and customized
+class   BatchFilesSpawner(WrapSpawner):
+    """BatchFilesSpawner allows batch commands to be displayed and customized
     before launch by a user via a HTML textfield.
     These commands are divided into two categories: System and User.
     System commands are available to all users, and User
     commands are stored in the specific user's home directory. The filepaths
     for these are set in the jupyterhub config by the following variables:
-    c.CustomSpawner.system_profile_path
-    c.CustomSpawner.user_profile_path
+    c.BatchFilesSpawner.system_profile_path
+    c.BatchFilesSpawner.user_profile_path
     """
 
     profiles = List(
@@ -399,23 +399,35 @@ class CustomSpawner(WrapSpawner):
 
     options_form = Unicode()
 
+    spawner_class = Unicode(config = True,
+                            default_value="SlurmSpawner")
+
+    system_profile_path = Unicode(config=True,
+                                  help="Directory path where batch files are stored")
+
+    user_profile_path = Unicode(config=True,
+                                help="Path to users' homedirectories")
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if 'spawner_class' in kwargs['config']['CustomSpawner']:
-            self.spawner_class = kwargs['config']['CustomSpawner']['spawner_class']
+        '''
+        if 'spawner_class' in kwargs['config']['BatchFilesSpawner']:
+            self.spawner_class = kwargs['config']['BatchFilesSpawner']['spawner_class']
             pass
         else:
             self.spawner_class = 'SlurmSpawner'
 
-        if 'system_profile_path' in kwargs['config']['CustomSpawner']:
-            self.system_profile_path = kwargs['config']['CustomSpawner']['system_profile_path']
+
+        if 'system_profile_path' in kwargs['config']['BatchFilesSpawner']:
+            self.system_profile_path = kwargs['config']['BatchFilesSpawner']['system_profile_path']
         else:
             self.system_profile_path = os.path.dirname(self.config.JupyterHub.config_file) + "/jupyterhub/profiles"
 
-        if 'user_profile_path' in kwargs['config']['CustomSpawner']:
-            self.user_profile_path = kwargs['config']['CustomSpawner']['user_profile_path']
+        if 'user_profile_path' in kwargs['config']['BatchFilesSpawner']:
+            self.user_profile_path = kwargs['config']['BatchFilesSpawner']['user_profile_path']
         else:
             self.user_profile_path = None
+            '''
 
     def _options_form_default(self):
         self._load_profiles_from_fs()


### PR DESCRIPTION
This Pull Request is for kind of WrapSpawner; the CustomSpawner. 

The CustomSpawner implements a new feature set for launching jobs; it displays the batch script to be run as a textfield in the launcher form, and it also allows the user to customize the script before launching the job. 

The profiles are stored in a System directory, allowing administrators to provide a global set of job profiles to be launched by storing files in the filesystem.

Optionally, users can store their own custom scripts to be launched in their own home directories if those directories are accessible by the JupyterHub server. 

This feature is being developed at the request of the EPA's High End Scientific Computing II (HESC2) project; we want to support the JupyterHub community by contributing code and would love to see this become an official feature. 

Contact me with any needed changes or enhancements. Looking forward to working with you all!

Jeff Edwards
edwards.jedwards@epa.gov
