### PR TITLE
Remove options_form from ProfilesSpawner, is inherited via Spawner

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -212,8 +212,6 @@ class ProfilesSpawner(WrapSpawner):
             the first item starts selected."""
         )
 
-    options_form = Unicode()
-
     def _options_form_default(self):
         temp_keys = [ dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles ]
         temp_keys[0]['first'] = self.first_template


### PR DESCRIPTION
Not sure why is this added here? The base `Spawner` makes  `options_form` configurable by default. Or am I missing something here?

Also would there be interest in moving towards how kubespawner takes care of profiles? https://github.com/jupyterhub/kubespawner/blob/cd4c08d5e175e3b6d58e279c27265e6e95e6197b/kubespawner/spawner.py#L1505

Or maybe it's time to push a bit more on https://github.com/jupyterhub/wrapspawner/issues/33 :)