### PR TITLE
Fix conflicting key with kubespawner

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -186,8 +186,8 @@ class ProfilesSpawner(WrapSpawner):
     child_profile = Unicode()
 
     form_template = Unicode(
-        """<label for="profile">Select a job profile:</label>
-        <select class="form-control" name="profile" required autofocus>
+        """<label for="wrap_profile">Select a job profile:</label>
+        <select class="form-control" name="wrap_profile" required autofocus>
         {input_template}
         </select>
         """,
@@ -219,7 +219,7 @@ class ProfilesSpawner(WrapSpawner):
 
     def options_from_form(self, formdata):
         # Default to first profile if somehow none is provided
-        return dict(profile=formdata.get('profile', [self.profiles[0][1]])[0])
+        return dict(wrap_profile=formdata.get('wrap_profile', [self.profiles[0][1]])[0])
 
     # load/get/clear : save/restore child_profile (and on load, use it to update child class/config)
 
@@ -232,20 +232,20 @@ class ProfilesSpawner(WrapSpawner):
                 break
 
     def construct_child(self):
-        self.child_profile = self.user_options.get('profile', "")
+        self.child_profile = self.user_options.get('wrap_profile', "")
         self.select_profile(self.child_profile)
         super().construct_child()
 
     def load_child_class(self, state):
         try:
-            self.child_profile = state['profile']
+            self.child_profile = state['wrap_profile']
         except KeyError:
             self.child_profile = ''
         self.select_profile(self.child_profile)
 
     def get_state(self):
         state = super().get_state()
-        state['profile'] = self.child_profile
+        state['wrap_profile'] = self.child_profile
         return state
 
     def clear_state(self):


### PR DESCRIPTION
https://github.com/jupyterhub/kubespawner 6.x is conflicting with this project. Version 6 now includes a way of configuring profiles a bit like `wrapspawner` but limited to kubernetes.
When they introduced this feature, they used the same key to get the right profile from the form. When trying to spawn a process with kubespawner from wrapspawner, it crashes with the following error:

```py
Exception in Future <Task finished name='Task-37' coro=<BaseHandler.spawn_single_user.<locals>.finish_user_spawn() done, defined at
    Traceback (most recent call last):
      File "/usr/local/lib/python3.11/site-packages/tornado/gen.py", line 625, in error_callback
        future.result()
      File "/usr/local/lib/python3.11/site-packages/jupyterhub/handlers/base.py", line 988, in finish_user_spawn
        await spawn_future
      File "/usr/local/lib/python3.11/site-packages/jupyterhub/user.py", line 902, in spawn
        raise e
      File "/usr/local/lib/python3.11/site-packages/jupyterhub/user.py", line 798, in spawn
        url = await gen.with_timeout(timedelta(seconds=spawner.start_timeout), f)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 2667, in _start
        await self.load_user_options()
      File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 3327, in load_user_options
        self._validate_user_options(profile_list
      File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 3132, in _validate_user_options
        profile = self._get_profile(profile_slug, profile_list
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 3176, in _get_profile
        raise ValueError
    ValueError: No such profile: kubespawner. Options include: 
```

This PR fixes this conflict by using a different key name, `wrap_profile`. I am currently using this fix in production and it's now working fine.

\cc @mbmilligan 
