### PR TITLE
Reverse patch server #51

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -147,20 +147,6 @@ class WrapSpawner(Spawner):
             else:
                 raise RuntimeError("No child spawner yet exists - can not get progress yet")
 
-    # Manually link server attribute since it is not a traitlet
-
-    @property
-    def server(self):
-        if not self.child_spawner:
-            self.construct_child()
-        return self.child_spawner.server
-
-    @server.setter
-    def server(self, server):
-        if not self.child_spawner:
-            self.construct_child()
-        self.child_spawner.server = server
-
 
 class ProfilesSpawner(WrapSpawner):
 


### PR DESCRIPTION
Since https://github.com/jupyterhub/jupyterhub/pull/3810, the fix brought by #51 on master but not yet release, breaks KubeSpawner. The spawner at least doesn't start without removing this patch, using `1.0.1` works but using the version on `master` fails.

See https://github.com/jupyterhub/wrapspawner/pull/50#issuecomment-1055291752

To test wrapSpawner, I used the KubeSpawner inside `z2jh` with the following configuration.

```python
c.ProfilesSpawner.profiles = [
    ('Kube', 'kubespawner', 'kubespawner.KubeSpawner', {
        'ip':'0.0.0.0', 'port': 0, 'cmd': None, 'path': None, 'environment': {}, 'env_keep': []}),
    # Other spawner here
]
```

I haven't tested with `BatchSpawner` yet but this is my next step, I will report any test progress here.

Fixes #54 