### PR TITLE
Fix named servers with `KubeSpawner`

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -74,6 +74,8 @@ class WrapSpawner(Spawner):
                 hub  = self.hub,
                 authenticator = self.authenticator,
                 oauth_client_id = self.oauth_client_id,
+                cookie_options = self.cookie_options,
+                orm_spawner = self.orm_spawner,
                 server = self._server,
                 config = self.config,
                 **self.child_config


### PR DESCRIPTION
Named servers is not working with `WrapSpawner` and `KubeSpawner`.

In the `__init__` of `KubeSpawner`, the following code is executed to compute the pvc name:

https://github.com/jupyterhub/kubespawner/blob/a4b9b190f0335406c33c6de11b5d1b687842dd89/kubespawner/spawner.py#L195

However, the parameter `self.name` provided comes from the computed property defined here:

https://github.com/jupyterhub/jupyterhub/blob/cc9d9e435ad1e0aa639afd37120d0d6cca2eca92/jupyterhub/spawner.py#L264

Which relies on `orm_spawner` which should normally be provided in the constructor:

https://github.com/jupyterhub/jupyterhub/blob/cc9d9e435ad1e0aa639afd37120d0d6cca2eca92/jupyterhub/spawner.py#L160

However, as `orm_spawner` is not provided in the constructor then the pvc name is not valid.
To fix this issue, we need to forward this additional variable in the constructor.

\cc @mbmilligan 

Fixes #26