### PR TITLE
Fail informatively when profile keys are not unique

### DIFF
--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -20,17 +20,15 @@ Using this mechanism, the administrator can provide users with a pre-approved
 selection of Spawner configurations.
 """
 
-import os
 import json
 import re
 import urllib.request
-import logging
 
-from tornado import gen, concurrent
+from tornado import concurrent
 
 from jupyterhub.spawner import LocalProcessSpawner, Spawner
 from traitlets import (
-    Instance, Type, Tuple, List, Dict, Integer, Unicode, Float, Any
+    Instance, Type, Tuple, List, Dict, Unicode, Any
 )
 from traitlets import directional_link, validate, TraitError
 

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -24,6 +24,7 @@ import os
 import json
 import re
 import urllib.request
+import logging
 
 from tornado import gen, concurrent
 
@@ -211,6 +212,14 @@ class ProfilesSpawner(WrapSpawner):
             first = "checked" (taken from first_template) for the first item in the list, so that
             the first item starts selected."""
         )
+
+    def __init__(self, *args, **kwargs):
+        super(ProfilesSpawner, self).__init__(*args, **kwargs)
+
+        keys = [p[1] for p in self.profiles]
+        if len(set(keys)) != len(keys):
+            logging.warning(
+                "Invalid spawners profiles config, profiles keys are not unique")
 
     def _options_form_default(self):
         temp_keys = [ dict(display=p[0], key=p[1], type=p[2], first='') for p in self.profiles ]

--- a/wrapspawner/wrapspawner.py
+++ b/wrapspawner/wrapspawner.py
@@ -32,7 +32,7 @@ from jupyterhub.spawner import LocalProcessSpawner, Spawner
 from traitlets import (
     Instance, Type, Tuple, List, Dict, Integer, Unicode, Float, Any
 )
-from traitlets import directional_link, validate
+from traitlets import directional_link, validate, TraitError
 
 # Only needed for DockerProfilesSpawner
 try:
@@ -192,7 +192,7 @@ class ProfilesSpawner(WrapSpawner):
         seen = set()
         duplicated = {p[1] for p in profiles if p[1] in seen or seen.add(p[1])}
         if len(duplicated):
-            logging.warning(
+            raise TraitError(
                 f"Invalid wrapspawner profiles, profiles keys are not unique : {duplicated}")
 
         return profiles


### PR DESCRIPTION
When the config is invalid and uses the same key for 2 different profiles, then no warning or errors are triggered !

This PR adds a warning message when 2 profiles are configured with the same key. The invalid config error may lead to unexpected behaviour by launching the wrong profile.

\cc @mbmilligan 